### PR TITLE
Ignore Development Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ web/app/upgrade
 web/app/uploads/*
 !web/app/uploads/.gitkeep
 
+# Config
+config/environments/development.php
+
 # WordPress
 web/wp
 web/.htaccess


### PR DESCRIPTION
Updated gitignore to ignore development config file so that we can customize our local install configurations.